### PR TITLE
Fix exception catch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,13 @@
 language: ruby
 rvm:
-  - 1.9.3
   - 1.8.7
+  - 1.9.3
   - 2.0.0
-  - 2.1.3
+  - 2.1.5
 before_install:
   - travis_retry sudo apt-get update
   - travis_retry sudo apt-get install libtokyocabinet-dev
-  - travis_retry sudo apt-get install libboost-program-options-dev libboost-regex-dev libboost-serialization-dev libboost-thread-dev
+  - travis_retry sudo apt-get install libboost-program-options-dev libboost-regex-dev libboost-serialization-dev libboost-thread-dev libboost-system-dev
   - travis_retry sudo apt-get install uuid-dev
   - git clone https://github.com/gree/flare.git flare
   - (cd flare && ./autogen.sh)

--- a/lib/flare/tools/cli/dispatch.rb
+++ b/lib/flare/tools/cli/dispatch.rb
@@ -41,6 +41,7 @@ class Flare::Tools::Cli::Dispatch
   end
 
   def main(subcommand_name, argv, as_subcommand)
+    prepare
     _main(subcommand_name, argv, as_subcommand)
   rescue => e
     level = 1
@@ -54,6 +55,10 @@ class Flare::Tools::Cli::Dispatch
   end
 
 private
+
+  def prepare
+    Thread.abort_on_exception = true
+  end
 
   def _main(subcommand_name, argv, as_subcommand)
     @subcommand_name = subcommand_name

--- a/lib/flare/tools/cli/stats.rb
+++ b/lib/flare/tools/cli/stats.rb
@@ -89,7 +89,6 @@ module Flare
           worker_threads = []
           queue = {}
 
-          Thread.abort_on_exception = true
           nodes.each do |hostname_port,data|
             queue[hostname_port] = SizedQueue.new(1)
             worker_threads << Thread.new(queue[hostname_port]) do |q|


### PR DESCRIPTION
On ruby-1.8.x Timeout::Error is subclass of Interrupt, not StandardError. So we should explicit catch Timeout::Error.
