### PR TITLE
Use Timeout.timeout instead of Object#timeout

### DIFF
--- a/lib/flare/test/daemon.rb
+++ b/lib/flare/test/daemon.rb
@@ -142,7 +142,7 @@ module Flare
       def kill_node_process(pid)
         STDERR.print " #{pid}"
         begin
-          timeout(10) do
+          Timeout.timeout(10) do
             Process.kill :TERM, pid
             Process.waitpid pid
           end

--- a/lib/flare/test/node.rb
+++ b/lib/flare/test/node.rb
@@ -45,7 +45,7 @@ module Flare
       def terminate
         puts "killing... #{@pid}"
         begin
-          timeout(10) do
+          Timeout.timeout(10) do
             Process.kill :TERM, @pid
             Process.waitpid @pid
           end

--- a/lib/flare/tools/client.rb
+++ b/lib/flare/tools/client.rb
@@ -37,7 +37,7 @@ module Flare
       def initialize(host, port, tout = DefaultTimeout, uplink_limit = DefalutBwlimit, downlink_limit = DefalutBwlimit)
         @tout = tout
         @conn = nil
-        timeout(1) do
+        Timeout.timeout(1) do
           @conn = Flare::Net::Connection.new(host, port, uplink_limit, downlink_limit)
         end
         @server_name, @version = server_version
@@ -80,7 +80,7 @@ module Flare
         response = nil
         cmd.chomp!
         cmd += "\r\n"
-        timeout(tout) do
+        Timeout.timeout(tout) do
           @conn.send(cmd)
           response = parser.call(@conn, processor)
         end
@@ -101,7 +101,7 @@ module Flare
 
       def close()
         begin
-          timeout(1) { quit }
+          Timeout.timeout(1) { quit }
         rescue Timeout::Error => e
         end
         @conn.close

--- a/test/unit/bwlimit_test.rb
+++ b/test/unit/bwlimit_test.rb
@@ -35,7 +35,7 @@ class BwlimitTest < Test::Unit::TestCase
     total = size*1024*duration
     bwlimit = Bwlimit.new("#{size}kB")
     assert_nothing_raised {
-      timeout(duration*1.5) {
+      Timeout.timeout(duration*1.5) {
         while bwlimit.totalbytes < total
           bwlimit.inc((1500*(rand+1)).to_i)
           bwlimit.wait


### PR DESCRIPTION
Object#timeout is deprecated with ruby2.3.